### PR TITLE
gz-ionic support

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -4,6 +4,7 @@
   gazebo = gazebo_classic;
   gazebo_11 = gazebo_classic;
   gz-harmonic = pkgs.callPackage ./gazebo-sim/8.nix {};
+  gz-ionic = pkgs.callPackage ./gazebo-sim/9.nix {};
   ignition-fortress = pkgs.callPackage ./gazebo-sim/6.nix {};
 
   libdart = pkgs.callPackage ./libdart {};
@@ -12,27 +13,32 @@
     cmake0 = pkgs.callPackage ./ignition/cmake/0.nix {};
     cmake2 = pkgs.callPackage ./ignition/cmake {};
     cmake3 = pkgs.callPackage ./ignition/cmake/3.nix {};
-    cmake = cmake3;
+    cmake4 = pkgs.callPackage ./ignition/cmake/4.nix {};
+    cmake = cmake4;
 
     common3 = pkgs.callPackage ./ignition/common/3.nix {};
     common4 = pkgs.callPackage ./ignition/common/4.nix {};
     common5 = pkgs.callPackage ./ignition/common/5.nix {};
-    common = common5;
+    common6 = pkgs.callPackage ./ignition/common/6.nix {};
+    common = common6;
 
     fuel-tools4 = pkgs.callPackage ./ignition/fuel-tools/4.nix {};
     fuel-tools7 = pkgs.callPackage ./ignition/fuel-tools/7.nix { };
     fuel-tools9 = pkgs.callPackage ./ignition/fuel-tools/9.nix {};
-    fuel-tools = fuel-tools9;
+    fuel-tools10 = pkgs.callPackage ./ignition/fuel-tools/10.nix {};
+    fuel-tools = fuel-tools10;
 
     math4 = pkgs.callPackage ./ignition/math/4.nix {};
     math6 = pkgs.callPackage ./ignition/math/6.nix {};
     math7 = pkgs.callPackage ./ignition/math/7.nix {};
-    math = math7;
+    math8 = pkgs.callPackage ./ignition/math/8.nix {};
+    math = math8;
 
     msgs5 = pkgs.callPackage ./ignition/msgs/5.nix {};
     msgs8 = pkgs.callPackage ./ignition/msgs/8.nix { };
     msgs10 = pkgs.callPackage ./ignition/msgs/10.nix {};
-    msgs = msgs10;
+    msgs11 = pkgs.callPackage ./ignition/msgs/11.nix {};
+    msgs = msgs11;
 
     tools1 = pkgs.libsForQt5.callPackage ./ignition/tools/1.nix {};
     tools2 = pkgs.libsForQt5.callPackage ./ignition/tools/2.nix {};
@@ -41,40 +47,49 @@
     transport8 = pkgs.callPackage ./ignition/transport/8.nix {};
     transport11 = pkgs.callPackage ./ignition/transport/11.nix { };
     transport13 = pkgs.callPackage ./ignition/transport/13.nix {};
-    transport = transport13;
+    transport14 = pkgs.callPackage ./ignition/transport/14.nix {};
+    transport = transport14;
 
     utils1 = pkgs.callPackage ./ignition/utils/1.nix {};
     utils2 = pkgs.callPackage ./ignition/utils/2.nix {};
-    utils = utils2;
+    utils3 = pkgs.callPackage ./ignition/utils/3.nix {};
+    utils = utils3;
 
     plugin1 = pkgs.callPackage ./ignition/plugin/1.nix {};
     plugin2 = pkgs.callPackage ./ignition/plugin/2.nix {};
-    plugin = plugin2;
+    plugin3 = pkgs.callPackage ./ignition/plugin/3.nix {};
+    plugin = plugin3;
 
     physics5 = pkgs.callPackage ./ignition/physics/5.nix {};
     physics7 = pkgs.callPackage ./ignition/physics/7.nix {};
-    physics = physics7;
+    physics8 = pkgs.callPackage ./ignition/physics/8.nix {};
+    physics = physics8;
 
     rendering6 = pkgs.libsForQt5.callPackage ./ignition/rendering/6.nix {};
     rendering8 = pkgs.libsForQt5.callPackage ./ignition/rendering/8.nix {};
-    rendering = rendering8;
+    rendering9 = pkgs.libsForQt5.callPackage ./ignition/rendering/9.nix {};
+    rendering = rendering9;
     gui6 = pkgs.libsForQt5.callPackage ./ignition/gui/6.nix {};
     gui8 = pkgs.libsForQt5.callPackage ./ignition/gui/8.nix {};
-    gui = gui8;
+    gui9 = pkgs.libsForQt5.callPackage ./ignition/gui/9.nix {};
+    gui = gui9;
     sensors6 = pkgs.libsForQt5.callPackage ./ignition/sensors/6.nix {};
     sensors8 = pkgs.libsForQt5.callPackage ./ignition/sensors/8.nix {};
-    sensors = sensors8;
+    sensors9 = pkgs.libsForQt5.callPackage ./ignition/sensors/9.nix {};
+    sensors = sensors9;
     launch7 = pkgs.libsForQt5.callPackage ./ignition/launch/7.nix {};
     launch = launch7;
     sim6 = pkgs.libsForQt5.callPackage ./ignition/sim/6.nix {};
     sim8 = pkgs.libsForQt5.callPackage ./ignition/sim/8.nix {};
-    sim = sim8;
+    sim9 = pkgs.libsForQt5.callPackage ./ignition/sim/9.nix {};
+    sim = sim9;
   };
   sdformat_9 = pkgs.callPackage ./sdformat/9.nix {};
   sdformat_12 = pkgs.callPackage ./sdformat/12.nix {};
   sdformat_13 = pkgs.callPackage ./sdformat/13.nix {};
   sdformat_14 = pkgs.callPackage ./sdformat/14.nix {};
-  sdformat = sdformat_14;
+  sdformat_15 = pkgs.callPackage ./sdformat/15.nix {};
+  sdformat = sdformat_15;
   ogre1_9 = pkgs.callPackage ./ogre/1.9.nix {};
   ogre-next = pkgs.callPackage ./ogre-next {};
 }

--- a/pkgs/gazebo-sim/9.nix
+++ b/pkgs/gazebo-sim/9.nix
@@ -1,0 +1,26 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "9";
+    version = "9.0.0";
+    srcHash = "sha256-B8H5lnQKJx9lULMcBVCsuEOGDeRYBh/biiiBUW91wAk=";
+    ignition-cmake = ignition.cmake4;
+    ignition-common = ignition.common6;
+    ignition-math = ignition.math8;
+    ignition-transport = ignition.transport14;
+    ignition-msgs = ignition.msgs11;
+    ignition-fuel-tools = ignition.fuel-tools10;
+    ignition-plugin = ignition.plugin3;
+    ignition-physics = ignition.physics8;
+    ignition-rendering = ignition.rendering9;
+    ignition-gui = ignition.gui9;
+    ignition-sensors = ignition.sensors9;
+    ignition-tools = ignition.tools2;
+    ignition-utils = ignition.utils3;
+    ignition-sim = ignition.sim9;
+    sdformat = ignition.sdformat15;
+  }
+  // args)

--- a/pkgs/gazebo-sim/default.nix
+++ b/pkgs/gazebo-sim/default.nix
@@ -15,9 +15,9 @@
   ignition-gui ? ignition.gui,
   ignition-sensors ? ignition.sensors,
   ignition-tools ? ignition.tools,
-  ignition-launch ? ignition.launch,
   ignition-utils ? ignition.utils,
   ignition-sim ? ignition.sim,
+  sdformat ? ignition.sdformat,
   makeWrapper,
   majorVersion ? "8",
   ...
@@ -40,7 +40,6 @@ symlinkJoin {
     ignition-physics
     ignition-gui
     ignition-sim
-    # ignition-launch
   ];
   buildInputs = [makeWrapper];
   postBuild =

--- a/pkgs/ignition/cmake/4.nix
+++ b/pkgs/ignition/cmake/4.nix
@@ -1,0 +1,7 @@
+{callPackage, ...} @ args:
+callPackage ./. ({
+    majorVersion = "4";
+    version = "4.0.0";
+    srcHash = "sha256-r1XQqx+JqH+ITZIaixgZjA/9weyPq8+LQ1N2ZsIdOK4=";
+  }
+  // args)

--- a/pkgs/ignition/cmake/default.nix
+++ b/pkgs/ignition/cmake/default.nix
@@ -40,6 +40,7 @@ stdenv.mkDerivation rec {
   ];
 
   nativeBuildInputs = [cmake];
+  buildInputs = [cmake];
   # pkg-config is needed to use some CMake modules in this package
   propagatedBuildInputs =
     [pkg-config]

--- a/pkgs/ignition/common/6.nix
+++ b/pkgs/ignition/common/6.nix
@@ -1,0 +1,15 @@
+# { callPackage, ignition, gz-cmake_3, gz-math_7, gz-utils_2, ... }@args:
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "6";
+    version = "6.0.1";
+    srcHash = "sha256-gVyqzyvdGxXKRm0mpiR1nIYvceWwUDMmp85bHTEpZOE=";
+    ignition-math = ignition.math8;
+    ignition-utils = ignition.utils3;
+    ignition-cmake = ignition.cmake4;
+  }
+  // args)

--- a/pkgs/ignition/common/default.nix
+++ b/pkgs/ignition/common/default.nix
@@ -54,6 +54,7 @@ stdenv.mkDerivation rec {
       })
     ];
 
+  buildInputs = [cmake];
   nativeBuildInputs = [cmake];
   propagatedNativeBuildInputs = [ignition-cmake assimp];
   propagatedBuildInputs =

--- a/pkgs/ignition/fuel-tools/10.nix
+++ b/pkgs/ignition/fuel-tools/10.nix
@@ -1,0 +1,13 @@
+{
+  callPackage,
+  ignition,
+} @ args:
+callPackage ./. ({
+    majorVersion = "10";
+    version = "10.0.1";
+    srcHash = "sha256-/Xfhec6kpv6srSp+hudqBaK4dKFn0QK45aGqxzNyytw=";
+    ignition-common = ignition.common6;
+    ignition-msgs = ignition.msgs11;
+    ignition-cmake = ignition.cmake4;
+  }
+  // args)

--- a/pkgs/ignition/fuel-tools/default.nix
+++ b/pkgs/ignition/fuel-tools/default.nix
@@ -35,6 +35,8 @@ stdenv.mkDerivation rec {
   propagatedNativeBuildInputs = [ignition-cmake];
   propagatedBuildInputs = [ignition-common tinyxml-2 curl jsoncpp libyaml libzip ignition-msgs];
 
+  buildInputs = [cmake];
+  
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];

--- a/pkgs/ignition/gui/8.nix
+++ b/pkgs/ignition/gui/8.nix
@@ -9,13 +9,13 @@ callPackage ./. ({
     srcHash = "sha256-l/DUgeXZfeBJWOLEveME/NrAqoi619gQrwAReYy7olc=";
     # version = "8.3.0";
     # srcHash = "sha256-V0zaL6qrd510hMECCr3/mMkyqf4yu2aaKLRZ6Rw0s/4=";
-    ignition-math = ignition.math;
-    ignition-plugin = ignition.plugin;
-    ignition-common = ignition.common;
-    ignition-transport = ignition.transport;
-    ignition-rendering = ignition.rendering;
-    ignition-msgs = ignition.msgs;
-    ignition-tools = ignition.tools;
-    ignition-cmake = ignition.cmake;
+    ignition-math = ignition.math7;
+    ignition-plugin = ignition.plugin2;
+    ignition-common = ignition.common5;
+    ignition-transport = ignition.transport13;
+    ignition-rendering = ignition.rendering8;
+    ignition-msgs = ignition.msgs10;
+    ignition-tools = ignition.tools2;
+    ignition-cmake = ignition.cmake3;
   }
   // args)

--- a/pkgs/ignition/gui/9.nix
+++ b/pkgs/ignition/gui/9.nix
@@ -1,0 +1,19 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "9";
+    version = "9.0.0";
+    srcHash = "sha256-/YJW6XmdGwbyd5Nx3wcTqnRlpwE1unVGaNX91qfZmiM=";
+    ignition-math = ignition.math8;
+    ignition-plugin = ignition.plugin3;
+    ignition-common = ignition.common6;
+    ignition-transport = ignition.transport14;
+    ignition-rendering = ignition.rendering9;
+    ignition-msgs = ignition.msgs11;
+    ignition-tools = ignition.tools2;
+    ignition-cmake = ignition.cmake4;
+  }
+  // args)

--- a/pkgs/ignition/gui/default.nix
+++ b/pkgs/ignition/gui/default.nix
@@ -49,6 +49,9 @@ stdenv.mkDerivation rec {
     wrapQtAppsHook
     patchelf
   ];
+
+  buildInputs = [cmake];
+
   # pkg-config is needed to use some CMake modules in this package
   # propagatedNativeBuildInputs = [
   #   ignition-cmake
@@ -83,7 +86,7 @@ stdenv.mkDerivation rec {
     ignition-cmake
   ];
 
-  patches = lib.optional (lib.versionAtLeast version "8") [
+  patches = lib.optional (lib.versionAtLeast version "8.0.0" && lib.versionOlder version "9.0.0") [
     # ./fix_cmake_plugins.patch
     ./gz-gui.patch
     # ./cmd.patch

--- a/pkgs/ignition/math/7.nix
+++ b/pkgs/ignition/math/7.nix
@@ -6,7 +6,7 @@
 callPackage ./. ({
     majorVersion = "7";
     version = "7.5.0";
-    srcHash = "sha256-E7u3EtpqNLvcqI5ycezwwAlbVHM3JdqeyLFWYlEaOYo=";
+    srcHash = "sha256-TEadejtPCR3FAUbyAAME28tmqaxypPTJDYidjZ3FPIY=";
     ignition-cmake = ignition.cmake3;
     ignition-utils = ignition.utils2;
   }

--- a/pkgs/ignition/math/8.nix
+++ b/pkgs/ignition/math/8.nix
@@ -4,10 +4,10 @@
   ...
 } @ args:
 callPackage ./. ({
-    majorVersion = "7";
-    version = "7.5.0";
+    majorVersion = "8";
+    version = "8.1.1";
     srcHash = "sha256-E7u3EtpqNLvcqI5ycezwwAlbVHM3JdqeyLFWYlEaOYo=";
-    ignition-cmake = ignition.cmake3;
-    ignition-utils = ignition.utils2;
+    ignition-cmake = ignition.cmake4;
+    ignition-utils = ignition.utils3;
   }
   // args)

--- a/pkgs/ignition/math/default.nix
+++ b/pkgs/ignition/math/default.nix
@@ -38,7 +38,7 @@ stdenv.mkDerivation rec {
       ignition-utils
     ];
 
-  # buildInputs = [ignition-utils eigen];
+  buildInputs = [cmake];
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];

--- a/pkgs/ignition/msgs/11.nix
+++ b/pkgs/ignition/msgs/11.nix
@@ -1,0 +1,14 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "11";
+    version = "11.0.2";
+    srcHash = "sha256-PUhFOmVPRiOVWfOjAU8z8dcxKPdcoTrgRwDGXP/vsUs=";
+    ignition-cmake = ignition.cmake4;
+    ignition-math = ignition.math8;
+    ignition-utils = ignition.utils3;
+  }
+  // args)

--- a/pkgs/ignition/msgs/default.nix
+++ b/pkgs/ignition/msgs/default.nix
@@ -31,7 +31,7 @@ stdenv.mkDerivation rec {
   };
 
   # Don't require Protobuf 3
-  patches = lib.optional (majorVersion != "10") [
+  patches = lib.optional (lib.versionOlder version "10.0.0") [
     (fetchpatch {
       url = "https://github.com/gazebosim/gz-msgs/commit/0c0926c37042ac8f5aeb49ac36101acd3e084c6b.patch";
       hash = "sha256-QnR1WtB4gbgyJKbQ4doMhfSjJBksEeQ3Us4y9KqCWeY=";
@@ -55,6 +55,8 @@ stdenv.mkDerivation rec {
     ignition-math
     ignition-utils
   ];
+
+  buildInputs = [cmake];
 
   # postInstall = ''
   #   mkdir ~/.gz/tools/configs -p

--- a/pkgs/ignition/physics/7.nix
+++ b/pkgs/ignition/physics/7.nix
@@ -7,10 +7,10 @@ callPackage ./. ({
     majorVersion = "7";
     version = "7.3.0";
     srcHash = "sha256-PTalEQc9C/QsYMO+XK7aOzZUzC01jxiW6bjdItB5hlM=";
-    ignition-cmake = ignition.cmake;
-    ignition-utils = ignition.utils;
-    ignition-plugin = ignition.plugin;
-    ignition-common = ignition.common;
-    ignition-math = ignition.math;
+    ignition-cmake = ignition.cmake3;
+    ignition-utils = ignition.utils2;
+    ignition-plugin = ignition.plugin2;
+    ignition-common = ignition.common5;
+    ignition-math = ignition.math7;
   }
   // args)

--- a/pkgs/ignition/physics/8.nix
+++ b/pkgs/ignition/physics/8.nix
@@ -1,0 +1,16 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "8";
+    version = "8.1.0";
+    srcHash = "sha256-FnVKVbPCn3B6/sZKiPJqUjUgVilwoeP/H97eg/dirz8";
+    ignition-cmake = ignition.cmake4;
+    ignition-utils = ignition.utils3;
+    ignition-plugin = ignition.plugin3;
+    ignition-common = ignition.common6;
+    ignition-math = ignition.math8;
+  }
+  // args)

--- a/pkgs/ignition/physics/default.nix
+++ b/pkgs/ignition/physics/default.nix
@@ -53,6 +53,8 @@ stdenv.mkDerivation rec {
     libdart
   ];
 
+  buildInputs = [cmake];
+
   # patches = [./dart.patch];
 
   cmakeFlags = [

--- a/pkgs/ignition/plugin/2.nix
+++ b/pkgs/ignition/plugin/2.nix
@@ -7,7 +7,7 @@ callPackage ./. ({
     majorVersion = "2";
     version = "2.0.3";
     srcHash = "sha256-9t6vcnBbfRWu6ptmqYAhmWKDoKAaK631JD9u1C0G0mY=";
-    ignition-cmake = ignition.cmake;
-    ignition-utils = ignition.utils;
+    ignition-cmake = ignition.cmake3;
+    ignition-utils = ignition.utils2;
   }
   // args)

--- a/pkgs/ignition/plugin/3.nix
+++ b/pkgs/ignition/plugin/3.nix
@@ -1,0 +1,13 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "3";
+    version = "3.0.1";
+    srcHash = "sha256-7v6fzylJ4R1uoyQFM+eyl2/bXVy5MGC5dPjS7/taB8U=";
+    ignition-cmake = ignition.cmake4;
+    ignition-utils = ignition.utils3;
+  }
+  // args)

--- a/pkgs/ignition/plugin/default.nix
+++ b/pkgs/ignition/plugin/default.nix
@@ -40,6 +40,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];
 
+  buildInputs = [cmake];
+
   meta = with lib; {
     homepage = "https://ignitionrobotics.org/libs/plugin";
     description = "Cross-platform C++ library for dynamically loading plugins.";

--- a/pkgs/ignition/rendering/8.nix
+++ b/pkgs/ignition/rendering/8.nix
@@ -7,9 +7,9 @@ callPackage ./. ({
     majorVersion = "8";
     version = "8.2.0";
     srcHash = "sha256-eaWkZKHu566Rub7YSO2lnKdj8YQbhl86v+JR4zrgtjs=";
-    ignition-math = ignition.math;
-    ignition-plugin = ignition.plugin;
-    ignition-common = ignition.common;
-    ignition-cmake = ignition.cmake;
+    ignition-math = ignition.math7;
+    ignition-plugin = ignition.plugin2;
+    ignition-common = ignition.common5;
+    ignition-cmake = ignition.cmake3;
   }
   // args)

--- a/pkgs/ignition/rendering/9.nix
+++ b/pkgs/ignition/rendering/9.nix
@@ -1,0 +1,15 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "9";
+    version = "9.1.0";
+    srcHash = "sha256-L2xkd93zhXtvbbzRrdjsoxbDtopp/RpcWBh1tfGvLeM=";
+    ignition-math = ignition.math8;
+    ignition-plugin = ignition.plugin3;
+    ignition-common = ignition.common6;
+    ignition-cmake = ignition.cmake4;
+  }
+  // args)

--- a/pkgs/ignition/rendering/default.nix
+++ b/pkgs/ignition/rendering/default.nix
@@ -59,6 +59,8 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];
 
+  buildInputs = [cmake];
+
   patches = lib.optional (majorVersion == "6") [./graphicsAPI.patch];
 
   meta = with lib; {

--- a/pkgs/ignition/sensors/8.nix
+++ b/pkgs/ignition/sensors/8.nix
@@ -7,11 +7,11 @@ callPackage ./. ({
     majorVersion = "8";
     version = "8.2.0";
     srcHash = "sha256-j/8kS+Bvaim2gtsZcp+/u8CAE+N24/5qZhciFR0Q8+M=";
-    ignition-plugin = ignition.plugin;
-    ignition-transport = ignition.transport;
-    ignition-rendering = ignition.rendering;
-    ignition-msgs = ignition.msgs;
-    ignition-cmake = ignition.cmake;
-    ignition-common = ignition.common;
+    ignition-plugin = ignition.plugin2;
+    ignition-transport = ignition.transport13;
+    ignition-rendering = ignition.rendering8;
+    ignition-msgs = ignition.msgs10;
+    ignition-cmake = ignition.cmake3;
+    ignition-common = ignition.common5;
   }
   // args)

--- a/pkgs/ignition/sensors/9.nix
+++ b/pkgs/ignition/sensors/9.nix
@@ -1,0 +1,17 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "9";
+    version = "9.1.0";
+    srcHash = "sha256-dMqJqp5229r/mKjBzUJD/tEbsYZANAFNycHYc7CIkz8=";
+    ignition-plugin = ignition.plugin3;
+    ignition-transport = ignition.transport14;
+    ignition-rendering = ignition.rendering9;
+    ignition-msgs = ignition.msgs11;
+    ignition-cmake = ignition.cmake4;
+    ignition-common = ignition.common6;
+  }
+  // args)

--- a/pkgs/ignition/sensors/default.nix
+++ b/pkgs/ignition/sensors/default.nix
@@ -51,6 +51,9 @@ stdenv.mkDerivation rec {
     sdformat
     eigen
   ];
+
+  buildInputs = [cmake];
+
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];

--- a/pkgs/ignition/sim/9.nix
+++ b/pkgs/ignition/sim/9.nix
@@ -1,0 +1,23 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "9";
+    version = "9.1.0";
+    srcHash = "sha256-niVXuqMvEhwCW2NcrEhIChh3DsD2M8ZTspDi+zF0kBc=";
+    ignition-cmake = ignition.cmake4;
+    ignition-common = ignition.common6;
+    ignition-math = ignition.math8;
+    ignition-transport = ignition.transport14;
+    ignition-msgs = ignition.msgs11;
+    ignition-fuel-tools = ignition.fuel-tools10;
+    ignition-plugin = ignition.plugin3;
+    ignition-physics = ignition.physics8;
+    ignition-rendering = ignition.rendering9;
+    ignition-gui = ignition.gui9;
+    ignition-sensors = ignition.sensors9;
+    ignition-tools = ignition.tools2;
+  }
+  // args)

--- a/pkgs/ignition/sim/default.nix
+++ b/pkgs/ignition/sim/default.nix
@@ -115,6 +115,8 @@ stdenv.mkDerivation rec {
     ]
     ++ lib.optional withBulletEngineSupport bullet;
 
+  buildInputs = [cmake];
+  
   dontWrapQtApps = true;
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"

--- a/pkgs/ignition/tools/default.nix
+++ b/pkgs/ignition/tools/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation rec {
   # pkg-config is needed to use some CMake modules in this package
   propagatedBuildInputs = [pkg-config ignition-cmake ruby];
   propagatedNativeBuildInputs = [qtquickcontrols2 qtgraphicaleffects];
-  buildInputs = [ronn];
+  buildInputs = [ronn cmake];
 
   dontWrapQtApps = true;
 
@@ -44,7 +44,6 @@ stdenv.mkDerivation rec {
     if (lib.versionAtLeast majorVersion "2")
     then ''wrapQtApp $out/bin/gz''
     else ''wrapQtApp $out/bin/ign'';
-
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];

--- a/pkgs/ignition/transport/14.nix
+++ b/pkgs/ignition/transport/14.nix
@@ -1,0 +1,11 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "14";
+    version = "14.0.0";
+    srcHash = "sha256-zoGphy2cpmqJsnyS1LNVm4eGtHCWkAwIblga4RdVj4k=";
+  }
+  // args)

--- a/pkgs/ignition/transport/default.nix
+++ b/pkgs/ignition/transport/default.nix
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [cmake];
   # propagatedNativeBuildInputs = [ ignition-cmake ];
   buildInputs =
-    [ignition-math sqlite libsodium ignition-utils ignition-cmake ignition-msgs]
+    [cmake ignition-math sqlite libsodium ignition-utils ignition-cmake ignition-msgs]
     ++ lib.optional (lib.versionAtLeast version "13") [python3];
   propagatedBuildInputs =
     [

--- a/pkgs/ignition/utils/3.nix
+++ b/pkgs/ignition/utils/3.nix
@@ -1,0 +1,13 @@
+{
+  callPackage,
+  ignition,
+  pkgs,
+  ...
+} @ args:
+callPackage ./. ({
+    majorVersion = "3";
+    version = "3.0.0";
+    srcHash = "sha256-maq0iGCGbrjVGwBNNIYYSAKXxszwlAJS4FLrGNxsA5c=";
+    ignition-cmake = ignition.cmake4;
+  }
+  // args)

--- a/pkgs/ignition/utils/default.nix
+++ b/pkgs/ignition/utils/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   fetchFromGitHub,
   cmake,
+  spdlog,
   ignition,
   ignition-cmake ? ignition.cmake,
   majorVersion ? "1",
@@ -26,8 +27,9 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [cmake];
-  propagatedBuildInputs = [ignition-cmake];
+  propagatedBuildInputs = [ignition-cmake] ++ lib.optional (lib.versionAtLeast (toString version) "3.0.0") spdlog;
 
+  buildInputs = [cmake];
   cmakeFlags = [
     "-DCMAKE_INSTALL_LIBDIR='lib'"
   ];

--- a/pkgs/sdformat/14.nix
+++ b/pkgs/sdformat/14.nix
@@ -7,7 +7,7 @@ callPackage ./generic.nix (args
   // {
     version = "14.4.0";
     srcHash = "sha256-U1K2BialJVBgrEDD+47UGJ4Ct6v1vdLuX1r3IO7h4Sk=";
-    gz-cmake = ignition.cmake;
-    gz-math = ignition.math;
-    gz-utils = ignition.utils;
+    gz-cmake = ignition.cmake3;
+    gz-math = ignition.math7;
+    gz-utils = ignition.utils2;
   })

--- a/pkgs/sdformat/15.nix
+++ b/pkgs/sdformat/15.nix
@@ -1,0 +1,13 @@
+{
+  callPackage,
+  ignition,
+  ...
+} @ args:
+callPackage ./generic.nix (args
+  // {
+    version = "15.2.0";
+    srcHash = "sha256-ckLFg0msHxYHciprbyW2ktN/D+m0w/Lhl9tPqQwJbXY=";
+    gz-cmake = ignition.cmake4;
+    gz-math = ignition.math8;
+    gz-utils = ignition.utils3;
+  })

--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@ in {
   default = pkgs.mkShell {
     name = "Gz sim development";
     buildInputs = [
-      pkgs.gz-harmonic
+      pkgs.gz-ionic
       nixgl
     ];
     QT_QPA_PLATFORM = "xcb";


### PR DESCRIPTION
Moin Bernd, 

- this PR updates all gz-packages to the latest major version in order to build gz-ionic (9). 

- ``cmake`` is added to ``buildInputs`` in all gz-packages as otherwise, the some dependencies are not found when building

Grüße 